### PR TITLE
Support b2clogin.com URLs over onmicrosoft.com URL

### DIFF
--- a/lib/omniauth/strategies/azure_active_directory_b2c/policy.rb
+++ b/lib/omniauth/strategies/azure_active_directory_b2c/policy.rb
@@ -4,17 +4,19 @@ module OmniAuth
       class Policy
         include AzureActiveDirectoryB2C::PolicyOptions
 
-        attr_reader :application_identifier, :application_secret, :issuer, :tenant_name, :policy_name, :jwk_signing_algorithm, :jwk_signing_keys
+        attr_reader :application_identifier, :application_secret, :issuer, :tenant_name, :tenant_guid, :policy_name, :jwk_signing_algorithm, :jwk_signing_keys, :idp_redirect_url_format
 
-        def initialize(application_identifier:, application_secret:, issuer:, tenant_name:, policy_name:, jwk_signing_algorithm:, jwk_signing_keys:, scope: nil)
+        def initialize(application_identifier:, application_secret:, issuer:, tenant_name:, tenant_guid: nil, policy_name:, jwk_signing_algorithm:, jwk_signing_keys:, scope: nil, idp_redirect_url_format: :deprecated)
           @application_identifier = application_identifier
           @application_secret = application_secret
           @issuer = issuer
           @tenant_name = tenant_name
+          @tenant_guid = tenant_guid
           @policy_name = policy_name
           @jwk_signing_algorithm = jwk_signing_algorithm
           @jwk_signing_keys = jwk_signing_keys
           @scope = *scope
+          @idp_redirect_url_format = idp_redirect_url_format
         end
 
         def scope

--- a/lib/omniauth/strategies/azure_active_directory_b2c/policy_options.rb
+++ b/lib/omniauth/strategies/azure_active_directory_b2c/policy_options.rb
@@ -37,7 +37,17 @@ module OmniAuth
         end
 
         def policy_host_name
-          'https://login.microsoftonline.com/te/%s/%s' % [tenant_name, policy_name]
+          case idp_redirect_url_format.to_s
+          when 'b2clogin_guid'
+            'https://%s.b2clogin.com/%s/%s' % [tenant_name, tenant_guid, policy_name]
+          when 'onmicrosoft'
+            'https://%s.b2clogin.com/%s.onmicrosoft.com/%s' % [tenant_name, tenant_name, policy_name]
+          else
+            # this is a deprecated format
+            tn = tenant_name.to_s
+            tn += '.onmicrosoft.com' unless tn.end_with?('.onmicrosoft.com')
+            'https://login.microsoftonline.com/te/%s/%s' % [tn, policy_name]
+          end
         end
 
         def policy_authorization_endpoint


### PR DESCRIPTION
Adds new optional configuration parameter for policy to effect a change to the IdP redirect URL.

Defaults to current behavior, or can pass `idp_redirect_url_format: "b2clogin_guid"` or `idp_redirect_url_format: "onmicrosoft"` to get one of two different redirect URL formats now supported by MS.

`b2clogin_guid` uses format `'https://%s.b2clogin.com/%s/%s' % [tenant_name, tenant_guid, policy_name]`
`onmicrosoft` uses format `'https://%s.b2clogin.com/%s.onmicrosoft.com/%s' % [tenant_name, tenant_name, policy_name]`

Note for both that `tenant_name` should contain only the tenant name, not resemble a domain.

Using `b2clogin_guid` means you should also pass an argument `tenant_guid: "<a GUID>"` (default is nil)


MS doc: https://docs.microsoft.com/en-us/azure/active-directory-b2c/b2clogin