### PR TITLE
Remove evaluate gem

### DIFF
--- a/lib/omniauth/strategies/azure_active_directory_b2c.rb
+++ b/lib/omniauth/strategies/azure_active_directory_b2c.rb
@@ -1,5 +1,4 @@
 require 'omniauth'
-require 'proc_evaluate'
 
 require_relative 'azure_active_directory_b2c/authentication_request.rb'
 require_relative 'azure_active_directory_b2c/authentication_response.rb'
@@ -59,7 +58,7 @@ module OmniAuth
       end
 
       def redirect_uri
-        @redirect_uri ||= options.redirect_uri.evaluate(self) || (raise MissingOptionError, '`redirect_uri` not defined')
+        @redirect_uri ||= options.redirect_uri || (raise MissingOptionError, '`redirect_uri` not defined')
       end
 
       def setup_phase

--- a/lib/omniauth/strategies/azure_active_directory_b2c/authentication_response.rb
+++ b/lib/omniauth/strategies/azure_active_directory_b2c/authentication_response.rb
@@ -89,6 +89,8 @@ module OmniAuth
           # TODO: if the id_token is not passed back, we could get the id token from the userinfo endpoint (or fail if no endpoint is defined?)
           encrypted_id_token = access_token.id_token
           decoded_id_token = decode_id_token!(encrypted_id_token)
+
+          decoded_id_token
         end
 
         def decode_id_token!(id_token)
@@ -104,7 +106,7 @@ module OmniAuth
         end
 
         def jwk_key
-          key = policy.jwk_signing_keys
+          key = policy.jwk_signing_keys.first
           if key.has_key?('keys')
             JSON::JWK::Set.new(key['keys']) # a set of keys
           else

--- a/lib/omniauth/strategies/azure_active_directory_b2c/policy.rb
+++ b/lib/omniauth/strategies/azure_active_directory_b2c/policy.rb
@@ -4,17 +4,19 @@ module OmniAuth
       class Policy
         include AzureActiveDirectoryB2C::PolicyOptions
 
-        attr_reader :application_identifier, :application_secret, :issuer, :tenant_name, :policy_name, :jwk_signing_algorithm, :jwk_signing_keys
+        attr_reader :application_identifier, :application_secret, :issuer, :tenant_name, :tenant_guid, :policy_name, :jwk_signing_algorithm, :jwk_signing_keys, :idp_redirect_url_format
 
-        def initialize(application_identifier:, application_secret:, issuer:, tenant_name:, policy_name:, jwk_signing_algorithm:, jwk_signing_keys:, scope: nil)
-          @application_identifier = application_identifier
-          @application_secret = application_secret
-          @issuer = issuer
-          @tenant_name = tenant_name
-          @policy_name = policy_name
-          @jwk_signing_algorithm = jwk_signing_algorithm
-          @jwk_signing_keys = jwk_signing_keys
-          @scope = *scope
+        def initialize(application_identifier:, application_secret:, issuer:, tenant_name:, tenant_guid: nil, policy_name:, jwk_signing_algorithm:, jwk_signing_keys:, scope: nil, idp_redirect_url_format: :deprecated)
+          @application_identifier  = application_identifier
+          @application_secret      = application_secret
+          @issuer                  = issuer
+          @tenant_name             = tenant_name
+          @tenant_guid             = tenant_guid
+          @policy_name             = policy_name
+          @jwk_signing_algorithm   = jwk_signing_algorithm
+          @jwk_signing_keys        = jwk_signing_keys
+          @scope                   = *scope
+          @idp_redirect_url_format = idp_redirect_url_format
         end
 
         def scope

--- a/lib/omniauth/strategies/azure_active_directory_b2c/policy_options.rb
+++ b/lib/omniauth/strategies/azure_active_directory_b2c/policy_options.rb
@@ -37,7 +37,17 @@ module OmniAuth
         end
 
         def policy_host_name
-          'https://login.microsoftonline.com/te/%s/%s' % [tenant_name, policy_name]
+          case idp_redirect_url_format.to_s
+            when 'b2clogin_guid'
+              'https://%s.b2clogin.com/%s/%s' % [tenant_name, tenant_guid, policy_name]
+            when 'onmicrosoft'
+              'https://%s.b2clogin.com/%s.onmicrosoft.com/%s' % [tenant_name, tenant_name, policy_name]
+            else
+              # this is a deprecated format
+              tenant_name = tenant_name.to_s
+              tenant_name += '.onmicrosoft.com' unless tenant_name.end_with?('.onmicrosoft.com')
+              'https://login.microsoftonline.com/te/%s/%s' % [tenant_name, policy_name]
+          end
         end
 
         def policy_authorization_endpoint

--- a/lib/omniauth/strategies/azure_active_directory_b2c/policy_options.rb
+++ b/lib/omniauth/strategies/azure_active_directory_b2c/policy_options.rb
@@ -21,7 +21,8 @@ module OmniAuth
         end
 
         def policy_application_secret
-          raise MissingOptionError, '`application_secret` not defined'
+          nil
+          # raise MissingOptionError, '`application_secret` not defined'
         end
 
         def policy_issuer
@@ -88,7 +89,7 @@ module OmniAuth
         def policy_default_client_options
           {
             identifier: application_identifier,
-            secret: application_secret,
+            # secret: application_secret,
             authorization_endpoint: authorization_endpoint,
             token_endpoint: token_endpoint,
             jwks_uri: jwks_uri,

--- a/lib/omniauth/strategies/azure_active_directory_b2c/version.rb
+++ b/lib/omniauth/strategies/azure_active_directory_b2c/version.rb
@@ -2,7 +2,7 @@ module OmniAuth
   module Strategies
     class AzureActiveDirectoryB2C
 
-      VERSION = '0.2.0'
+      VERSION = '0.2.1'
 
     end
   end

--- a/omniauth-azure_active_directory_b2c.gemspec
+++ b/omniauth-azure_active_directory_b2c.gemspec
@@ -31,5 +31,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'omniauth', '~> 2.0'
   spec.add_dependency 'openid_connect', '~> 1.1'
-  spec.add_dependency 'proc_evaluate', '~> 1.0'
 end

--- a/omniauth-azure_active_directory_b2c.gemspec
+++ b/omniauth-azure_active_directory_b2c.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |spec|
     'Brent Jacobs',
     'NextFaze',
     'Meeco',
-    'Fishz'
+    'Fishz',
+    'kefon94'
   ]
 
   spec.files = [
@@ -28,7 +29,7 @@ Gem::Specification.new do |spec|
       'lib/omniauth/strategies/azure_active_directory_b2c/version.rb',
     ]
 
-  spec.add_dependency 'omniauth', '~> 1.3'
+  spec.add_dependency 'omniauth', '~> 2.0'
   spec.add_dependency 'openid_connect', '~> 1.1'
   spec.add_dependency 'proc_evaluate', '~> 1.0'
 end

--- a/omniauth-azure_active_directory_b2c.gemspec
+++ b/omniauth-azure_active_directory_b2c.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
     'Brent Jacobs',
     'NextFaze',
     'Meeco',
+    'Fishz'
   ]
 
   spec.files = [


### PR DESCRIPTION
The gem proc_evaluete is locked to ruby version 2 which prevent the update to ruby 3.
Only used for one specific case, the setup of the redirect url which is override by our implementation.